### PR TITLE
OSOE-855: Updating actions/cache to v4 to get rid of Node 16 deprecation warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,19 +44,19 @@ jobs:
         ) >> "$GITHUB_OUTPUT"
     - name: retrieve perl libraries arch
       id: retrieve-perl-libraries-arch
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitearch }}
         key: ${{ steps.perl-config.outputs.perl-key }}-arch
     - name: retrieve perl libraries lib
       id: retrieve-perl-libraries-lib
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitelib }}
         key: ${{ steps.perl-config.outputs.perl-key }}-lib
     - name: retrieve jd
       id: retrieve-jd
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ~/go/bin/jd
         key: jd-${{ runner.os }}
@@ -91,20 +91,20 @@ jobs:
     - name: save perl libraries arch
       if: ${{ steps.retrieve-perl-libraries-arch.outputs.cache-hit != 'true' }}
       id: save-perl-libraries-arch
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitearch }}
         key: ${{ steps.perl-config.outputs.perl-key }}-arch
     - name: save perl libraries lib
       if: ${{ steps.retrieve-perl-libraries-lib.outputs.cache-hit != 'true' }}
       id: save-perl-libraries-lib
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitelib }}
         key: ${{ steps.perl-config.outputs.perl-key }}-lib
     - name: save jd
       if: ${{ steps.retrieve-jd.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ~/go/bin/jd
         key: jd-${{ runner.os }}

--- a/action.yml
+++ b/action.yml
@@ -462,7 +462,7 @@ runs:
     - name: retrieve-dictionaries
       id: retrieve-dictionaries
       if: ${{ env.DICTIONARY_URLS_HASH }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ env.THIS_ACTION_PATH }}/dictionaries
         key: check-spelling-dictionaries-${{ env.DICTIONARY_URLS_HASH }}-${{ github.sha}}
@@ -487,14 +487,14 @@ runs:
     - name: retrieve perl libraries arch
       id: retrieve-perl-libraries-arch
       if: steps.perl-config.outputs.installsitearch
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitearch }}
         key: ${{ steps.perl-config.outputs.perl-key }}-arch
     - name: retrieve perl libraries lib
       id: retrieve-perl-libraries-lib
       if: steps.perl-config.outputs.installsitelib
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitelib }}
         key: ${{ steps.perl-config.outputs.perl-key }}-lib
@@ -525,7 +525,7 @@ runs:
         unknown-words
       shell: bash
     - name: save-dictionaries
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       if: (success() || failure()) && steps.spelling.outputs.CACHE_DICTIONARIES == '1'
       with:
         path: ${{ env.THIS_ACTION_PATH }}/dictionaries
@@ -533,14 +533,14 @@ runs:
     - name: save perl libraries arch
       if: ${{ (success() || (failure() && env.MERGE_FAILED != '1')) && steps.retrieve-perl-libraries-arch.outputs.cache-hit != 'true' && steps.perl-config.outputs.installsitearch }}
       id: save-perl-libraries-arch
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitearch }}
         key: ${{ steps.perl-config.outputs.perl-key }}-arch
     - name: save perl libraries lib
       if: ${{ (success() || (failure() && env.MERGE_FAILED != '1')) && steps.retrieve-perl-libraries-lib.outputs.cache-hit != 'true' && steps.perl-config.outputs.installsitelib }}
       id: save-perl-libraries-lib
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ${{ steps.perl-config.outputs.installsitelib }}
         key: ${{ steps.perl-config.outputs.perl-key }}-lib


### PR DESCRIPTION
Not opening a contrib to the original repo because this is already fixed [in the `prerelease` branch](https://github.com/check-spelling/check-spelling/blob/prerelease/action.yml#L555). We just need these updates to get rid of the warnings.